### PR TITLE
Fix logrus error argument

### DIFF
--- a/server/utils.go
+++ b/server/utils.go
@@ -40,7 +40,7 @@ func writeJsonResponse(w http.ResponseWriter, statusCode int, body any) {
 	}
 
 	if writeError != nil {
-		logrus.WithError(err).Errorf("failed to write json response with status=%d and body: %s", statusCode, string(response))
+		logrus.WithError(writeError).Errorf("failed to write json response with status=%d and body: %s", statusCode, string(response))
 	}
 }
 


### PR DESCRIPTION
## Summary
- log write errors using `logrus.WithError(writeError)` in `writeJsonResponse`

## Testing
- `go vet ./...` *(fails: access denied)*
- `go build ./...` *(fails: access denied)*

------
https://chatgpt.com/codex/tasks/task_b_685940edd440832ba4f8d6854c51058d